### PR TITLE
`extends` clause can have an expression

### DIFF
--- a/src/language/javascript.js
+++ b/src/language/javascript.js
@@ -143,7 +143,7 @@ extend('javascript', [
             3: 'storage.modifier.extends',
             4: 'entity.other.inherited-class'
         },
-        pattern: /(class)\s+(\w+)(?:\s+(extends)\s+(\w+))?(?=\s*\{)/g
+        pattern: /(class)\s+(\w+)(?:\s+(extends)\s+([\w\.\(\)]+))?(?=\s*\{)/g
     },
     {
         name: 'storage.type.function.arrow',


### PR DESCRIPTION
For now, I'm just allowing dots and parens